### PR TITLE
Update to latest ScalaTest release candidate version

### DIFF
--- a/src/main/scala/de/heikoseeberger/sbtfresh/Template.scala
+++ b/src/main/scala/de/heikoseeberger/sbtfresh/Template.scala
@@ -91,7 +91,7 @@ private object Template {
        |
        |object Version {
        |  final val Scala     = "2.11.8"
-       |  final val ScalaTest = "3.0.0-RC1"
+       |  final val ScalaTest = "3.0.0-RC2"
        |}
        |
        |object Library {


### PR DESCRIPTION
Latest version is RC2 (see http://www.scalatest.org/release_notes/3.0.0)