### PR TITLE
Use GitBranchPrompt from sbt-git if setUpGit is set

### DIFF
--- a/src/main/scala/de/heikoseeberger/sbtfresh/Fresh.scala
+++ b/src/main/scala/de/heikoseeberger/sbtfresh/Fresh.scala
@@ -80,8 +80,11 @@ private final class Fresh(buildDir: Path,
   def writeScalafmt(): Path =
     write(".scalafmt.conf", Template.scalafmtConf)
 
-  def writeShellPrompt(): Path =
-    write("shell-prompt.sbt", Template.shellPrompt)
+  def writeShellPrompt(useGitPrompt: Boolean): Path =
+    if (useGitPrompt)
+      write("shell-prompt.sbt", Template.shellPromptWithGit)
+    else
+      write("shell-prompt.sbt", Template.shellPrompt)
 
   def writeTravisYml(): Path =
     write(".travis.yml", Template.travisYml)

--- a/src/main/scala/de/heikoseeberger/sbtfresh/FreshPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtfresh/FreshPlugin.scala
@@ -147,7 +147,7 @@ object FreshPlugin extends AutoPlugin {
     fresh.writePlugins()
     fresh.writeReadme()
     fresh.writeScalafmt()
-    fresh.writeShellPrompt()
+    fresh.writeShellPrompt(setUpGit)
     if (setUpTravis) fresh.writeTravisYml()
     if (setUpGit) fresh.initialCommit()
 

--- a/src/main/scala/de/heikoseeberger/sbtfresh/Template.scala
+++ b/src/main/scala/de/heikoseeberger/sbtfresh/Template.scala
@@ -313,6 +313,12 @@ private object Template {
        |}
        |""".stripMargin
 
+  def shellPromptWithGit: String =
+    """|import com.typesafe.sbt.SbtGit.GitCommand
+       |
+       |shellPrompt.in(ThisBuild) := GitCommand.prompt
+       |""".stripMargin
+
   def travisYml: String =
     """|language: scala
        |


### PR DESCRIPTION
If a git repository is initialised (`setUpGit := true`) then the shell
prompt from the sbt-git plugin is used which displays the project name
followed by the currently active branch name.

This is somewhat opinionated so feel free to reject this pull request if that is not okay to you.
