### PR TITLE
Provide setting for using prompt from sbt-git if desired

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ target
 
 # ENSIME
 .ensime
+.ensime_cache
 .ensime_lucene
 
 # Mac

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ freshOrganization := "doe.john"        // Organization – "default" by default
 freshAuthor       := "John Doe"        // Author – value of "user.name" system property or "default" by default
 freshLicense      := Some(License.mit) // Optional license – `apache20` by default
 freshSetUpGit     := true              // Initialize a Git repo and create an initial commit – `true` by default
+freshUseGitPrompt := true              // Use the prompt from the sbt-git plugin - `false` by default
 ```
 
 Other settings which probably shouldn't be set globally:
@@ -45,6 +46,7 @@ arguments (hit tab for auto completion) which override the respective settings:
 - `license`
 - `setUpGit`
 - `setUpTravis`
+- `useGitPrompt`
 
 Example:
 

--- a/src/main/scala/de/heikoseeberger/sbtfresh/Fresh.scala
+++ b/src/main/scala/de/heikoseeberger/sbtfresh/Fresh.scala
@@ -80,8 +80,11 @@ private final class Fresh(buildDir: Path,
   def writeScalafmt(): Path =
     write(".scalafmt.conf", Template.scalafmtConf)
 
-  def writeShellPrompt(): Path =
-    write("shell-prompt.sbt", Template.shellPrompt)
+  def writeShellPrompt(useGitPrompt: Boolean): Path =
+    if (useGitPrompt)
+      write("shell-prompt.sbt", Template.shellPromptWithGit)
+    else
+      write("shell-prompt.sbt", Template.shellPrompt)
 
   def writeTravisYml(): Path =
     write(".travis.yml", Template.travisYml)

--- a/src/main/scala/de/heikoseeberger/sbtfresh/FreshPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtfresh/FreshPlugin.scala
@@ -61,6 +61,11 @@ object FreshPlugin extends AutoPlugin {
         "Configure Travis for Continuous Integration"
       )
 
+    val freshUseGitPrompt: SettingKey[Boolean] =
+      settingKey(
+        "Configure the sbt prompt to use the one provided by sbt-git - `false` by default"
+      )
+
     private def licenseIds =
       License.values.toVector.sortBy(_.id).mkString(", ")
   }
@@ -72,6 +77,7 @@ object FreshPlugin extends AutoPlugin {
     final val License      = "license"
     final val SetUpGit     = "setUpGit"
     final val SetUpTravis  = "setUpTravis"
+    final val UseGitPrompt = "useGitPrompt"
   }
 
   private final case class Args(organization: Option[String],
@@ -79,7 +85,8 @@ object FreshPlugin extends AutoPlugin {
                                 author: Option[String],
                                 license: Option[License],
                                 setUpGit: Option[Boolean],
-                                setUpTravis: Option[Boolean])
+                                setUpTravis: Option[Boolean],
+                                useGitPrompt: Option[Boolean])
 
   private final val DefaultOrganization = "default"
   private final val DefaultAuthor       = "default"
@@ -100,7 +107,8 @@ object FreshPlugin extends AutoPlugin {
       freshAuthor := sys.props.getOrElse("user.name", DefaultAuthor),
       freshLicense := DefaultLicense,
       freshSetUpGit := true,
-      freshSetUpTravis := true
+      freshSetUpTravis := true,
+      freshUseGitPrompt := false
     )
   }
 
@@ -119,8 +127,9 @@ object FreshPlugin extends AutoPlugin {
       arg(Arg.Author, token(StringBasic)).? ~ // Without token tab completion becomes non-computable!
       arg(Arg.License, licenseParser).? ~
       arg(Arg.SetUpGit, Bool).? ~
-      arg(Arg.SetUpTravis, Bool).?
-    args.map { case o ~ n ~ a ~ l ~ g ~ t => Args(o, n, a, l, g, t) }
+      arg(Arg.SetUpTravis, Bool).? ~
+      arg(Arg.UseGitPrompt, Bool).?
+    args.map { case o ~ n ~ a ~ l ~ g ~ t ~ gp => Args(o, n, a, l, g, t, gp) }
   }
 
   private def effect(state: State, args: Args) = {
@@ -135,6 +144,7 @@ object FreshPlugin extends AutoPlugin {
     val license      = args.license.orElse(setting(freshLicense))
     val setUpGit     = args.setUpGit.getOrElse(setting(freshSetUpGit))
     val setUpTravis  = args.setUpTravis.getOrElse(setting(freshSetUpTravis))
+    val useGitPrompt = args.useGitPrompt.getOrElse(setting(freshUseGitPrompt))
 
     val fresh = new Fresh(buildDir, organization, name, author, license)
     fresh.writeAutomateScalafmtPlugin()
@@ -147,7 +157,7 @@ object FreshPlugin extends AutoPlugin {
     fresh.writePlugins()
     fresh.writeReadme()
     fresh.writeScalafmt()
-    fresh.writeShellPrompt()
+    fresh.writeShellPrompt(useGitPrompt)
     if (setUpTravis) fresh.writeTravisYml()
     if (setUpGit) fresh.initialCommit()
 

--- a/src/main/scala/de/heikoseeberger/sbtfresh/Template.scala
+++ b/src/main/scala/de/heikoseeberger/sbtfresh/Template.scala
@@ -313,6 +313,12 @@ private object Template {
        |}
        |""".stripMargin
 
+  def shellPromptWithGit: String =
+    """|import com.typesafe.sbt.SbtGit.GitCommand
+       |
+       |shellPrompt.in(ThisBuild) := GitCommand.prompt
+       |""".stripMargin
+
   def travisYml: String =
     """|language: scala
        |


### PR DESCRIPTION
This adds a setting `freshUseGitPrompt` and a flag `useGitPrompt` which
defaults to `false`. If enabled sbt will be configured to use the prompt
from the sbt-git plugin.

Add `.ensime_cache` directory to `.gitignore` file.