### PR TITLE
Add support for wartremover sbt plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ most probably sits at `~/.sbt/0.13/build.sbt`:
 import de.heikoseeberger.sbtfresh.FreshPlugin.autoImport._
 import de.heikoseeberger.sbtfresh.license.License
 
-freshOrganization := "doe.john"        // Organization – "default" by default
-freshAuthor       := "John Doe"        // Author – value of "user.name" system property or "default" by default
-freshLicense      := Some(License.mit) // Optional license – `apache20` by default
-freshSetUpGit     := true              // Initialize a Git repo and create an initial commit – `true` by default
-freshSetUpTravis  := true              // Configure Travis for Continuous Integration - `true` by default
-freshUseGitPrompt := true              // Use the prompt from the sbt-git plugin - `false` by default
+freshOrganization     := "doe.john"        // Organization – "default" by default
+freshAuthor           := "John Doe"        // Author – value of "user.name" system property or "default" by default
+freshLicense          := Some(License.mit) // Optional license – `apache20` by default
+freshSetUpGit         := true              // Initialize a Git repo and create an initial commit – `true` by default
+freshSetUpTravis      := true              // Configure Travis for Continuous Integration - `true` by default
+freshSetUpWartremover := true              // Include the sbt wartremover (http://www.wartremover.org) plugin - `false` by default
+freshUseGitPrompt     := true              // Use the prompt from the sbt-git plugin - `false` by default
 ```
 
 Other settings which probably shouldn't be set globally:
@@ -47,6 +48,7 @@ arguments (hit tab for auto completion) which override the respective settings:
 - `license`
 - `setUpGit`
 - `setUpTravis`
+- `setUpWartremover`
 - `useGitPrompt`
 
 Example:

--- a/src/main/scala/de/heikoseeberger/sbtfresh/Fresh.scala
+++ b/src/main/scala/de/heikoseeberger/sbtfresh/Fresh.scala
@@ -49,7 +49,7 @@ private final class Fresh(buildDir: Path,
   def writeBuildProperties(): Path =
     write("project/build.properties", Template.buildProperties)
 
-  def writeBuildSbt(useGitPrompt: Boolean, setUpTravis: Boolean): Path =
+  def writeBuildSbt(useGitPrompt: Boolean, setUpTravis: Boolean, setUpWartremover: Boolean): Path =
     write(
       "build.sbt",
       Template.buildSbt(organization,
@@ -58,7 +58,8 @@ private final class Fresh(buildDir: Path,
                         author,
                         license,
                         useGitPrompt,
-                        setUpTravis)
+                        setUpTravis,
+                        setUpWartremover)
     )
 
   def writeGitignore(): Path =
@@ -75,8 +76,8 @@ private final class Fresh(buildDir: Path,
     write(path, Template.`package`(packageSegments, author))
   }
 
-  def writePlugins(setUpTravis: Boolean): Path =
-    write("project/plugins.sbt", Template.plugins(setUpTravis))
+  def writePlugins(setUpTravis: Boolean, setUpWartremover: Boolean): Path =
+    write("project/plugins.sbt", Template.plugins(setUpTravis, setUpWartremover))
 
   def writeReadme(): Path =
     write("README.md", Template.readme(name, license))


### PR DESCRIPTION
Add the flag `freshSetUpWartremover` which defaults to `false`. If set to `true` it will include the sbt [wartremover](http://www.wartremover.org) plugin and enable the default Wart detection settings which check for common pitfalls and unsafe operations in respect to functional programming style.