### PR TITLE
Remove `unmanagedSourceDirectories` settings (see #184)

### DIFF
--- a/src/main/scala/de/heikoseeberger/sbtfresh/Template.scala
+++ b/src/main/scala/de/heikoseeberger/sbtfresh/Template.scala
@@ -115,9 +115,7 @@ private object Template {
         |      "-target:jvm-1.8",
         |      "-encoding", "UTF-8",
         |      "-Ywarn-unused:imports",
-        |    ),
-        |    Compile / unmanagedSourceDirectories := Seq((Compile / scalaSource).value),
-        |    Test / unmanagedSourceDirectories := Seq((Test / scalaSource).value)$wartremoverSettings,
+        |    )$wartremoverSettings,
         |)
         |
         |lazy val scalafmtSettings =


### PR DESCRIPTION
This fixes problems where the compiler does not find classes when cross
compiling sources from different scala versions.

fixes #184 